### PR TITLE
Image type changed to the latest.

### DIFF
--- a/Practice/Deep Learning/gcp/create_instance_cpu.sh
+++ b/Practice/Deep Learning/gcp/create_instance_cpu.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-IMAGE_FAMILY="tf-1-11-cpu"
+IMAGE_FAMILY="tf-latest-cpu"
 ZONE="europe-west4-a"
 INSTANCE_NAME="tp-isae-dev-cpu"
 


### PR DESCRIPTION
Unless there is a reason to use TF 1.11 this image name will be using the latest TF (e.g.e. 1.12 as of today.).